### PR TITLE
Fix deployment HPC-61616

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ var
 sdist
 develop-eggs
 .installed.cfg
+.eggs
 
 # Installer logs
 pip-log.txt

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -789,7 +789,7 @@ class GpfsOperations(PosixOperations):
                    }
 
         opts = []
-        opts += ["-%s %s" % (typ2opt[typ], id)]
+        opts += ["-%s" % typ2opt[typ], "%s" % id]
         opts += ["-t", "%s" % int(grace)]
 
         opts.append(obj)

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -858,7 +858,7 @@ class GpfsOperations(PosixOperations):
             self.raiseException("setQuota: can't set hard limit %s lower then soft limit %s" %
                                 (hard, soft), GpfsOperationError)
 
-        opts += ["-%s" % typ2opt[typ], who]
+        opts += ["-%s" % typ2opt[typ], "%s" % who]
         opts += ["-s", "%sm" % int(soft / 1024 ** 2)]  # round to MB
         opts += ["-h", "%sm" % int(hard / 1024 ** 2)]  # round to MB
 
@@ -871,7 +871,7 @@ class GpfsOperations(PosixOperations):
 
     def list_snapshots(self, filesystem):
         """ List the snapshots of the given filesystem """
-        try: 
+        try:
             snaps = self._executeY('mmlssnapshot', [filesystem])
             return snaps['directory']
         except GpfsOperationError as err:
@@ -895,7 +895,7 @@ class GpfsOperations(PosixOperations):
         opts = [fsname, snapname]
         ec, out = self._execute('mmcrsnapshot', opts, True)
         if ec > 0:
-            self.log.raiseException("create_filesystem_snapshot: mmcrsnapshot with opts %s failed: %s" 
+            self.log.raiseException("create_filesystem_snapshot: mmcrsnapshot with opts %s failed: %s"
                 % (opts, out), GpfsOperationError)
 
         return ec == 0
@@ -915,7 +915,7 @@ class GpfsOperations(PosixOperations):
         opts = [fsname, snapname]
         ec, out = self._execute('mmdelsnapshot', opts, True)
         if ec > 0:
-            self.log.raiseException("delete_filesystem_snapshot: mmdelsnapshot with opts %s failed: %s" 
+            self.log.raiseException("delete_filesystem_snapshot: mmdelsnapshot with opts %s failed: %s"
                 % (opts, out), GpfsOperationError)
         return ec == 0
 

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -662,7 +662,7 @@ class GpfsOperations(PosixOperations):
                                (fsetpath, mntpt, fileset_name))
 
         # bail if there is a fileset with the same name or the same link location, i.e., path
-        for efsetid, efset in self.gpfslocalfilesets[foundgpfsdevice].items():
+        for efset in self.gpfslocalfilesets[foundgpfsdevice].values():
             efsetpath = efset.get('path', None)
             efsetname = efset.get('filesetName', None)
             if efsetpath == fsetpath or efsetname == fileset_name:
@@ -770,7 +770,7 @@ class GpfsOperations(PosixOperations):
         """
         self._set_grace(obj, 'fileset', grace)
 
-    def _set_grace(self, obj, typ, grace=0, id=0):
+    def _set_grace(self, obj, typ, grace=0, id_=0):
         """Set the grace period for a given type of objects in GPFS.
 
         @type obj: the path or the GPFS device
@@ -789,7 +789,7 @@ class GpfsOperations(PosixOperations):
                    }
 
         opts = []
-        opts += ["-%s" % typ2opt[typ], "%s" % id]
+        opts += ["-%s" % typ2opt[typ], "%s" % id_]
         opts += ["-t", "%s" % int(grace)]
 
         opts.append(obj)
@@ -847,7 +847,7 @@ class GpfsOperations(PosixOperations):
 
         soft2hard_factor = 1.05
 
-        if not typ in typ2opt:
+        if typ not in typ2opt:
             self.log.raiseException("_set_quota: unsupported type %s" % typ, GpfsOperationError)
 
         opts = []
@@ -867,7 +867,6 @@ class GpfsOperations(PosixOperations):
         ec, out = self._execute('tssetquota', opts, True)
         if ec > 0:
             self.log.raiseException("_set_quota: tssetquota with opts %s failed" % (opts), GpfsOperationError)
-
 
     def list_snapshots(self, filesystem):
         """ List the snapshots of the given filesystem """
@@ -900,7 +899,7 @@ class GpfsOperations(PosixOperations):
 
         return ec == 0
 
-    def delete_filesystem_snapshot(self,fsname, snapname):
+    def delete_filesystem_snapshot(self, fsname, snapname):
         """
         Delete a full filesystem snapshot
             @type fsname: string representing the name of the filesystem
@@ -915,8 +914,8 @@ class GpfsOperations(PosixOperations):
         opts = [fsname, snapname]
         ec, out = self._execute('mmdelsnapshot', opts, True)
         if ec > 0:
-            self.log.raiseException("delete_filesystem_snapshot: mmdelsnapshot with opts %s failed: %s"
-                % (opts, out), GpfsOperationError)
+            self.log.raiseException("delete_filesystem_snapshot: mmdelsnapshot with opts %s failed: %s" %
+                (opts, out), GpfsOperationError)
         return ec == 0
 
 

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -437,7 +437,7 @@ class GpfsOperations(PosixOperations):
         self.list_filesystems()  # make sure we have the latest information
         try:
             return self.gpfslocalfilesystems[filesystem]
-        except KeyError, _:
+        except KeyError:
             self.log.raiseException("GPFS has no information for filesystem %s" % (filesystem), GpfsOperationError)
 
     def get_fileset_info(self, filesystem_name, fileset_name):
@@ -485,10 +485,10 @@ class GpfsOperations(PosixOperations):
             # - means disk offline, so no nodename
             alldomains = ['.'.join(x.split('.')[1:]) for x in infoM['IOPerformedOnNode'] if x not in ['-', 'localhost']]
             if len(set(alldomains)) > 1:
-                self.log.error("More then one domain found: %s." % alldomains)
+                self.log.error("More than one domain found: %s." % alldomains)
             commondomain = alldomains[0]  # TODO: should be most frequent one
-        except KeyError:
-            self.log.exception("Can't determine domainname for nodes %s" % infoM['IOPerformedOnNode'])
+        except (IndexError, KeyError):
+            self.log.exception("Cannot determine domainname for nodes %s" % infoM['IOPerformedOnNode'])
             commondomain = None
 
         for idx, node in enumerate(infoM['IOPerformedOnNode']):

--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -220,7 +220,7 @@ class PosixOperations(object):
 
         try:
             fsid = os.stat(obj).st_dev  # this resolves symlinks
-        except:
+        except OSError:
             self.log.exception("Failed to get fsid from obj %s" % obj)
             return
 
@@ -249,7 +249,7 @@ class PosixOperations(object):
             # returns [('rootfs', '/', 2051L, 'rootfs'), ('ext4', '/', 2051L, '/dev/root'), ('tmpfs', '/dev', 17L, '/dev'), ...
             self.localfilesystemnaming = ['type', 'mountpoint', 'id', 'device']
             self.localfilesystems = [[y[2], y[1], os.stat(y[1]).st_dev, y[0]] for y in currentmounts]
-        except:
+        except (IOError, OSError):
             self.log.exception("Failed to create the list of current mounted filesystems")
             raise
 
@@ -347,7 +347,7 @@ class PosixOperations(object):
             else:
                 os.makedirs(obj)
                 return True
-        except OSError, err:
+        except OSError as err:
             if err.errno == errno.EEXIST:
                 return False
             else:
@@ -440,7 +440,7 @@ class PosixOperations(object):
             self.log.info("Changing ownership of %s to %s:%s" % (f, user_id, group_id))
             try:
                 self.chown(user_id, group_id, f)
-            except OSError, _:
+            except OSError:
                 self.log.raiseException("Cannot change ownership of file %s to %s:%s" %
                                         (f, user_id, group_id), PosixOperationError)
 
@@ -455,6 +455,11 @@ class PosixOperations(object):
             @type who: identifier (eg username or userid)
             @type grace: int, grace period in seconds
         """
+        del grace
+        del hard
+        del typ
+        del who
+        del soft
         obj = self._sanity_check(obj)
         self.log.error("setQuota not implemented for this class %s" % self.__class__.__name__)
 
@@ -468,7 +473,7 @@ class PosixOperations(object):
                 self.log.info("Chown on %s to %s:%s. Dry-run, so not actually changing this ownership" % (obj, owner, group))
             else:
                 os.chown(obj, owner, group)
-        except OSError, _:
+        except OSError:
             self.log.raiseException("Cannot change ownership of object %s to %s:%s" % (obj, owner, group),
                                     PosixOperationError)
 
@@ -487,7 +492,7 @@ class PosixOperations(object):
                 self.log.info("Chmod on %s to %s. Dry-run, so not actually changing access permissions" % (obj, permissions))
             else:
                 os.chmod(obj, permissions)
-        except OSError, _:
+        except OSError:
             self.log.raiseException("Could not change the permissions on object %s to %o" % (obj, permissions),
                                     PosixOperationError)
 
@@ -507,7 +512,7 @@ class PosixOperations(object):
             if os.path.isdir(obj):
                 try:
                     os.rmdir(obj)
-                except OSError, err:
+                except OSError:
                     self.log.exception("Cannot remove directory %s" % (obj))
             else:
                 os.unlink(obj)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from vsc.install.shared_setup import ag, kh, sdw
 
 
 PACKAGE = {
-    'version': '0.30.4',
+    'version': '0.30.5',
     'author': [sdw, ag, kh],
     'maintainer': [sdw, ag, kh],
     'tests_require': ['mock'],

--- a/test/gpfs.py
+++ b/test/gpfs.py
@@ -18,8 +18,8 @@ Tests for the gpfs library.
 
 @author: Andy Georges (Ghent University)
 """
-import subprocess
 import mock
+import os
 import vsc.filesystem.gpfs as gpfs
 
 from vsc.install.testing import TestCase
@@ -98,15 +98,14 @@ class ToolsTest(TestCase):
 
         self.assertTrue(len(set(map(len, split_lines))) == 1)  # all lines have the same number of fields
 
-
     @mock.patch('vsc.filesystem.gpfs.GpfsOperations._execute')
     def test_list_snapshots(self, mock_exec):
-        mock_exec.return_value=(1, 'mocked!')
+        mock_exec.return_value = (1, 'mocked!')
         gpfsi = gpfs.GpfsOperations()
         self.assertRaises(gpfs.GpfsOperationError, gpfsi.list_snapshots, 'fstest')
         mock_exec.assert_called_once_with('mmlssnapshot', ['fstest', '-Y'])
         lssnapshot_output = "mmlssnapshot::HEADER:version:reserved:reserved:filesystemName:directory:snapID:status:created:quotas:data:metadata:fileset:snapType: \nmmlssnapshot::0:1:::fstest:autumn_20151012:1517:Valid:Mon Oct 12 14%3A24%3A41 2015::0:0:::\nmmlssnapshot::0:1:::fstest:okt_20151028:1518:Valid:Wed Oct 28 11%3A34%3A06 2015::0:0:::"
-        mock_exec.return_value=(0, lssnapshot_output)
+        mock_exec.return_value = (0, lssnapshot_output)
         self.assertEqual(gpfsi.list_snapshots('fstest'), ['autumn_20151012', 'okt_20151028'])
 
     @mock.patch('vsc.filesystem.gpfs.GpfsOperations._execute')
@@ -115,10 +114,10 @@ class ToolsTest(TestCase):
         mock_list.return_value = ['autumn_20151012', 'okt_20151028']
         gpfsi = gpfs.GpfsOperations()
         self.assertEqual(gpfsi.create_filesystem_snapshot('fstest', 'okt_20151028'),0)
-        mock_exec.return_value=(1, 'mocked!')
+        mock_exec.return_value = (1, 'mocked!')
         self.assertRaises(gpfs.GpfsOperationError, gpfsi.create_filesystem_snapshot, 'fstest', '@backup')
         mock_exec.assert_called_once_with('mmcrsnapshot', ['fstest', '@backup'], True)
-        mock_exec.return_value=(0, 'mocked!')
+        mock_exec.return_value =( 0, 'mocked!')
         self.assertTrue(gpfsi.create_filesystem_snapshot('fstest', 'backup'))
 
     @mock.patch('vsc.filesystem.gpfs.GpfsOperations._execute')
@@ -127,9 +126,48 @@ class ToolsTest(TestCase):
         mock_list.return_value = ['autumn_20151012', 'okt_20151028']
         gpfsi = gpfs.GpfsOperations()
         self.assertEqual(gpfsi.delete_filesystem_snapshot('fstest', 'backup'),0)
-        mock_exec.return_value=(1, 'mocked!')
+        mock_exec.return_value = (1, 'mocked!')
         self.assertRaises(gpfs.GpfsOperationError, gpfsi.delete_filesystem_snapshot, 'fstest', 'autumn_20151012')
         mock_exec.assert_called_once_with('mmdelsnapshot', ['fstest', 'autumn_20151012'], True)
-        mock_exec.return_value=(0, 'mocked!')
+        mock_exec.return_value = (0, 'mocked!')
         self.assertTrue(gpfsi.delete_filesystem_snapshot('fstest', 'okt_20151028'))
 
+    @mock.patch('vsc.filesystem.posix.PosixOperations._execute')
+    @mock.patch('vsc.filesystem.gpfs.GpfsOperations._sanity_check')
+    @mock.patch('vsc.filesystem.gpfs.GpfsOperations.exists')
+    def test__set_grace(self, mock_exists, mock_sanity_check, mock_execute):
+        """Test that the command passes is properly constrcuted so it can be executed by execve."""
+
+        test_path = os.path.join("user", "scratchdelcatty", "gent", "vsc400", "vsc40075")
+        mock_sanity_check.return_value = test_path
+        mock_exists.return_value = True
+
+        gpfsi = gpfs.GpfsOperations()
+        mock_execute.return_value = (0, "")
+
+        gpfsi._set_grace(test_path, 'user', 7*24*60*60)
+
+        (args, _) = mock_execute.call_args
+        self.assertTrue(isinstance(args[0], list))
+        self.assertTrue(all([isinstance(a, str) for a in args[0]]))
+        self.assertTrue(all([len(s.split(" ")) == 1 for s in args[0]]))
+
+    @mock.patch('vsc.filesystem.posix.PosixOperations._execute')
+    @mock.patch('vsc.filesystem.gpfs.GpfsOperations._sanity_check')
+    @mock.patch('vsc.filesystem.gpfs.GpfsOperations.exists')
+    def test__set_quota(self, mock_exists, mock_sanity_check, mock_execute):
+        """Test that the command passed is properly constructed so it can be executed by execve."""
+
+        test_path = os.path.join("user", "scratchdelcatty", "gent", "vsc400", "vsc40075")
+        mock_sanity_check.return_value = test_path
+        mock_exists.return_value = True
+
+        gpfsi = gpfs.GpfsOperations()
+        mock_execute.return_value = (0, "")
+
+        gpfsi._set_quota(1024, 2540075, test_path)
+
+        (args, _) = mock_execute.call_args
+        self.assertTrue(isinstance(args[0], list))
+        self.assertTrue(all([isinstance(a, str) for a in args[0]]))
+        self.assertTrue(all([len(s.split(" ")) == 1 for s in args[0]]))

--- a/test/gpfs.py
+++ b/test/gpfs.py
@@ -136,7 +136,7 @@ class ToolsTest(TestCase):
     @mock.patch('vsc.filesystem.gpfs.GpfsOperations._sanity_check')
     @mock.patch('vsc.filesystem.gpfs.GpfsOperations.exists')
     def test__set_grace(self, mock_exists, mock_sanity_check, mock_execute):
-        """Test that the command passes is properly constrcuted so it can be executed by execve."""
+        """Test that the command passes is properly constructed so it can be executed by execve."""
 
         test_path = os.path.join("user", "scratchdelcatty", "gent", "vsc400", "vsc40075")
         mock_sanity_check.return_value = test_path


### PR DESCRIPTION
- the options were not passed along correctly
    - list had an int instead of a string
    - two arguments were passed in a single list entry

tcnhw. ever.