### PR TITLE
actually fix ignore fuse.sshfs as used by x2go (HPC-7499)

### DIFF
--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -39,7 +39,7 @@ OS_LINUX_IGNORE_FILESYSTEMS = ('rootfs',  # special initramfs filesystem
                                'ipathfs',  # qlogic IB
                                'binfmt_misc',  # ?
                                'rpc_pipefs',  # NFS RPC
-                               'fusefs',  # Fused stuff
+                               'fuse.sshfs',  # X2GO sshfs over fuse
                                )
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from vsc.install.shared_setup import ag, kh, sdw, kw
 
 
 PACKAGE = {
-    'version': '0.37.1',
+    'version': '0.38.1',
     'author': [sdw, ag, kh],
     'maintainer': [sdw, ag, kh, kw],
     'tests_require': ['mock'],


### PR DESCRIPTION
the fix implemented in https://github.com/hpcugent/vsc-filesystems/pull/57 does not work.