### PR TITLE
Support creating symlinks in dry run for non-existing targets

### DIFF
--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -309,7 +309,7 @@ class PosixOperations(with_metaclass(Singleton, object)):
                     target_ = os.path.realpath(target)
                     os.unlink(target)
                     target = self._sanity_check(target_)
-        else:
+        elif not self.dry_run:
             self.log.raiseException("Target %s does not exist, cannot make symlink to it" % (target),
                                     PosixOperationError)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ from vsc.install.shared_setup import ag, kh, sdw, kw, wdp
 
 
 PACKAGE = {
-    'version': '0.40.0',
+    'version': '0.40.1',
     'author': [sdw, ag, kh],
     'maintainer': [sdw, ag, kh, kw, wdp],
     'tests_require': ['mock'],


### PR DESCRIPTION
Currently you cannot create a symlink in dry run mode for a target that
does not yet exists. This is annoying as the target is often created in
the same code. So in dry run mode it should not raise an exception.