### PR TITLE
Add operator module and extra quota methods to GpfsOperations

### DIFF
--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -404,7 +404,7 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
 
         for idx, (fs, qt, qid) in enumerate(zip(info['filesystemName'], info['quotaType'], info['id'])):
             details = {k: info[k][idx] for k in datakeys}
-            if qt == Typ2Param.FILESET.value:
+            if qt == self.quota_types.FILESET.value:
                 # GPFS fileset quota have empty filesetName field
                 details['filesetname'] = details['name']
             res[fs][qt][qid].append(StorageQuota(**details))
@@ -543,7 +543,7 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
         @type quota_id: string with quota ID
         @type filesystem_name: string with device name
         """
-        fileset_quotas = self.gpfslocalquotas[filesystem_name][Typ2Param.FILESET.value]
+        fileset_quotas = self.gpfslocalquotas[filesystem_name][self.quota_types.FILESET.value]
 
         if quota_id not in fileset_quotas:
             errmsg = "Fileset quota '%s' not found in GPFS filesystem '%s'" % (quota_id, filesystem_name)
@@ -560,8 +560,8 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
         @type quota_id: string with quota ID
         @type filesystem_name: string with device name
         """
-        user_quotas = self.gpfslocalquotas[filesystem_name][Typ2Param.USR.value]
-        group_quotas = self.gpfslocalquotas[filesystem_name][Typ2Param.GRP.value]
+        user_quotas = self.gpfslocalquotas[filesystem_name][self.quota_types.USR.value]
+        group_quotas = self.gpfslocalquotas[filesystem_name][self.quota_types.GRP.value]
 
         if quota_id not in user_quotas and quota_id not in group_quotas:
             errmsg = "USR/GRP quota '%s' not found in GPFS filesystem '%s'" % (quota_id, filesystem_name)

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -38,7 +38,7 @@ from vsc.utils.patterns import Singleton
 
 GPFS_BIN_PATH = '/usr/lpp/mmfs/bin'
 
-GpfsQuota = namedtuple('GpfsQuota',
+StorageQuota = namedtuple('StorageQuota',
     ['name',
      'blockUsage', 'blockQuota', 'blockLimit', 'blockInDoubt', 'blockGrace',
      'filesUsage', 'filesQuota', 'filesLimit', 'filesInDoubt', 'filesGrace',
@@ -394,7 +394,7 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
             if qt == 'FILESET':
                 # GPFS fileset quota have empty filesetName field
                 details['filesetname'] = details['name']
-            res[fs][qt][qid] = [GpfsQuota(**details)]
+            res[fs][qt][qid] = [StorageQuota(**details)]
 
         self.gpfslocalquotas = res
         return res

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -867,8 +867,9 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
 
         @type obj: string representing the path where the GPFS was mounted or the device itself
         @type grace: grace period expressed in seconds
+        @type who: identifier (eg username or UID)
         """
-        del who
+        _ = who  # avoid lint error, unused in GPFS as user is determined from obj ownership
         self._set_grace(obj, 'user', grace)
 
     def set_group_grace(self, obj, grace=0, who=None):
@@ -876,8 +877,9 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
 
         @type obj: string representing the path where the GPFS was mounted or the device itself
         @type grace: grace period expressed in seconds
+        @type who: identifier (eg group name or GID)
         """
-        del who
+        _ = who  # avoid lint error, unused in GPFS as group is determined from obj ownership
         self._set_grace(obj, 'group', grace)
 
     def set_fileset_grace(self, obj, grace=0):

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -32,13 +32,14 @@ from socket import gethostname
 from itertools import dropwhile
 from enum import Enum
 
-from vsc.config.base import GPFS_DEFAULT_INODE_LIMIT
+from vsc.config.base import DEFAULT_INODE_MAX, DEFAULT_INODE_PREALLOC
 from vsc.filesystem.posix import PosixOperations, PosixOperationError
 from vsc.utils import fancylogger
 from vsc.utils.missing import nub, find_sublist_index, Monoid, MonoidDict, RUDict
 from vsc.utils.patterns import Singleton
 
 GPFS_BIN_PATH = '/usr/lpp/mmfs/bin'
+GPFS_DEFAULT_INODE_LIMIT = "%d:%d" % (DEFAULT_INODE_MAX, DEFAULT_INODE_PREALLOC)
 
 StorageQuota = namedtuple('StorageQuota',
     ['name',

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -521,6 +521,22 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
 
         return None
 
+    def get_fileset_name(self, filesystem_name, fileset_id):
+        """
+        Return name of fileset ID
+
+        @type filesystem_name: string representing a OceanStor filesystem
+        @type fileset_name: string representing a OceanStor fileset ID
+        """
+        self.list_filesets(devices=filesystem_name)
+        try:
+            fileset_name = self.oceanstor_filesets[filesystem_name][fileset_id]['filesetName']
+        except KeyError:
+            errmsg = "Fileset ID '%s' not found in OceanStor filesystem '%s'" % (fileset_id, filesystem_name)
+            self.log.raiseException(errmsg, OceanStorOperationError)
+
+        return fileset_name
+
     def _list_disk_single_device(self, device):
         """Return disk info for specific device
             both -M and -L info

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -864,20 +864,22 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
         self._set_quota(soft, who=fileset_name, obj=fileset_path, typ='fileset', hard=hard,
                         inode_soft=inode_soft, inode_hard=inode_hard)
 
-    def set_user_grace(self, obj, grace=0):
+    def set_user_grace(self, obj, grace=0, who=None):
         """Set the grace period for user data.
 
         @type obj: string representing the path where the GPFS was mounted or the device itself
         @type grace: grace period expressed in seconds
         """
+        del who
         self._set_grace(obj, 'user', grace)
 
-    def set_group_grace(self, obj, grace=0):
+    def set_group_grace(self, obj, grace=0, who=None):
         """Set the grace period for user data.
 
         @type obj: string representing the path where the GPFS was mounted or the device itself
         @type grace: grace period expressed in seconds
         """
+        del who
         self._set_grace(obj, 'group', grace)
 
     def set_fileset_grace(self, obj, grace=0):

--- a/lib/vsc/filesystem/lustre.py
+++ b/lib/vsc/filesystem/lustre.py
@@ -526,20 +526,22 @@ class LustreOperations(with_metaclass(Singleton, PosixOperations)):
             self._set_quota(who=project, obj=fileset_path, typ=Typ2Opt.project, soft=soft, hard=hard,
                             inode_soft=inode_soft, inode_hard=inode_hard)
 
-    def set_user_grace(self, obj, grace=0):
+    def set_user_grace(self, obj, grace=0, who=None):
         """Set the grace period for user data.
 
         @type obj: string representing the path where the FS was mounted
         @type grace: grace period expressed in seconds
         """
+        del who
         self._set_grace(obj, Typ2Opt.user, grace)
 
-    def set_group_grace(self, obj, grace=0):
+    def set_group_grace(self, obj, grace=0, who=None):
         """Set the grace period for group data.
 
         @type obj: string representing the path where the FS was mounted
         @type grace: grace period expressed in seconds
         """
+        del who
         self._set_grace(obj, Typ2Opt.group, grace)
 
     def set_fileset_grace(self, obj, grace=0):

--- a/lib/vsc/filesystem/lustre.py
+++ b/lib/vsc/filesystem/lustre.py
@@ -130,6 +130,8 @@ class LustreOperations(with_metaclass(Singleton, PosixOperations)):
         self.filesets = {}
         self.quotadump = '/var/cache/lustre'
 
+        self.quota_types = Typ2Param
+
     def set_default_mapping(self, default_mapping=None):
         ''' Set the class for the mapping of ids and search paths'''
         self.default_mapping = default_mapping

--- a/lib/vsc/filesystem/operator.py
+++ b/lib/vsc/filesystem/operator.py
@@ -61,10 +61,16 @@ class StorageOperator(object):
         Operator = None
         OperatorError = None
 
+        try:
+            # use ModuleNotFoundError if available (Python 3.6+)
+            ModuleImportError = ModuleNotFoundError
+        except NameError:
+            ModuleImportError = ImportError
+
         backend_module_name = '.'.join(['vsc', 'filesystem', backend])
         try:
             backend_module = importlib.import_module(backend_module_name)
-        except (ImportError, ModuleNotFoundError):
+        except ModuleImportError:
             logging.exception("Failed to load %s module", backend_module_name)
             raise
 

--- a/lib/vsc/filesystem/operator.py
+++ b/lib/vsc/filesystem/operator.py
@@ -25,7 +25,7 @@ def load_storage_operator(storage):
     Load and initialize corresponding operator class for this filesystem
     Return *Operations object
 
-    @type storage: Storage object from vsc.config
+    @type storage: storage attribute from a VscStorage instance (which is a Storage object)
     """
     if getattr(storage, 'backend_operator', None):
         return storage.backend_operator

--- a/lib/vsc/filesystem/operator.py
+++ b/lib/vsc/filesystem/operator.py
@@ -41,7 +41,7 @@ def load_storage_operator(storage):
     Operator, OperatorError = import_operator(storage.backend)
 
     try:
-        storage.backend_operator = Operator(**storage.api)
+        storage.backend_operator = Operator(**storage.operator_config)
     except TypeError:
         logging.exception("Operator of storage backend not found: %s", storage.backend)
         raise

--- a/lib/vsc/filesystem/operator.py
+++ b/lib/vsc/filesystem/operator.py
@@ -25,7 +25,7 @@ STORAGE_OPERATORS = ('Posix', 'Gpfs', 'OceanStor', 'Lustre')
 OPERATOR_CLASS_SUFFIX = 'Operations'
 OPERATOR_ERROR_CLASS_SUFFIX = 'OperationError'
 
-class StorageOperator:
+class StorageOperator(object):
     """
     Load and initialize the operator class to manage the storage
     """

--- a/lib/vsc/filesystem/operator.py
+++ b/lib/vsc/filesystem/operator.py
@@ -1,0 +1,77 @@
+# -*- coding: latin-1 -*-
+#
+# Copyright 2009-2022 Ghent University
+#
+# This file is part of vsc-filesystems,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# the Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/hpcugent/vsc-filesystems
+#
+# All rights reserved.
+#
+"""
+Interface to dynamically load vsc.filesystem modules and instantiate its XxxxOperations class
+
+@author: Alex Domingo (Vrije Universiteit Brussel)
+"""
+import logging
+
+def load_storage_operator(storage):
+    """
+    Load and initialize corresponding operator class for this filesystem
+    Return *Operations object
+
+    @type storage: Storage object from vsc.config
+    """
+    if getattr(storage, 'backend_operator', None):
+        return storage.backend_operator
+
+    Operator, OperatorError = import_operator(storage.backend)
+
+    try:
+        storage.backend_operator = Operator(**storage.api)
+    except TypeError:
+        logging.exception("Operator of storage backend not found: %s", storage.backend)
+        raise
+    else:
+        storage.backend_operator_err = OperatorError
+
+    return storage.backend_operator
+
+def import_operator(backend):
+    """
+    Import corresponding filesystem operator class and exception for storage backend
+
+    @type backend: string with name of storage backend
+    """
+    Operator = None
+    OperatorError = None
+
+    if backend == 'posix':
+        try:
+            from vsc.filesystem.posix import PosixOperations as Operator, PosixOperationError as OperatorError
+        except ImportError:
+            logging.exception("Failed to load PosixOperations from vsc.filesystem.posix")
+            raise
+    elif backend == 'gpfs':
+        try:
+            from vsc.filesystem.gpfs import GpfsOperations as Operator, GpfsOperationError as OperatorError
+        except ImportError:
+            logging.exception("Failed to load GpfsOperations from vsc.filesystem.gpfs")
+            raise
+    elif backend == 'oceanstor':
+        try:
+            from vsc.filesystem.oceanstor import OceanStorOperations as Operator
+            from vsc.filesystem.oceanstor import OceanStorOperationError as OperatorError
+        except ImportError:
+            logging.exception("Failed to load OceanStorOperations from vsc.filesystem.oceanstor")
+            raise
+    else:
+        logging.error("Storage backend '%s' is unsupported by vsc.filesystem", backend)
+
+    return Operator, OperatorError
+

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ else:
     install_requires.append('pyyaml')
 
 PACKAGE = {
-    'version': '1.2.19',
+    'version': '1.3.0',
     'author': [sdw, ag, kh, kw],
     'maintainer': [sdw, ag, kh, kw, wdp],
     'setup_requires': ['vsc-install >= 0.15.2'],

--- a/test/gpfs.py
+++ b/test/gpfs.py
@@ -357,3 +357,11 @@ mmhealth:State:0:1:::test01.gastly.data:OBJECT:test01.gastly.data:NODE:DISABLED:
             for test_quota in TEST_LOCAL_QUOTAS['fstest']['USR'][test_user]:
                 test_grace = gpfsi.determine_grace_periods(test_quota)
                 self.assertEqual(test_grace, ref_grace[test_user])
+
+    def test_get_grace_expiration(self):
+        gpfsi = gpfs.GpfsOperations()
+        self.assertEqual(gpfsi._get_grace_expiration("6 days"), (True, 6 * 86400))
+        self.assertEqual(gpfsi._get_grace_expiration("2 hours"), (True, 2 * 3600))
+        self.assertEqual(gpfsi._get_grace_expiration("13 minutes"), (True, 13 * 60))
+        self.assertEqual(gpfsi._get_grace_expiration("expired"), (True, 0))
+        self.assertEqual(gpfsi._get_grace_expiration("none"), (False, None))

--- a/test/gpfs.py
+++ b/test/gpfs.py
@@ -26,6 +26,53 @@ import vsc.filesystem.gpfs as gpfs
 
 from vsc.install.testing import TestCase
 
+TEST_LOCAL_FILESETS = {
+    'fstest': {
+        '0': {'filesetName': 'foo'},
+        '1': {'filesetName': 'bar'},
+        '2': {'filesetName': 'fs1'},
+        '3': {'filesetName': 'fs2'},
+    },
+}
+ 
+TEST_LOCAL_QUOTAS = {
+    'fstest': {
+        'FILESET': {
+            '0': [
+                gpfs.StorageQuota(
+                    name='0', remarks='', quota='on', defQuota='off', fid='0', filesetname='0',
+                    blockUsage=4, blockQuota=1024, blockLimit=1024, blockInDoubt=0, blockGrace='none',
+                    filesUsage=1, filesQuota=1024, filesLimit=1024, filesInDoubt=0, filesGrace='none'
+                ),
+            ],
+        },
+        'USR': {
+            '2510001': [
+                gpfs.StorageQuota(
+                    name='0', remarks='', quota='on', defQuota='off', fid='0', filesetname='0',
+                    blockUsage=4, blockQuota=1024, blockLimit=1024, blockInDoubt=0, blockGrace='none',
+                    filesUsage=1, filesQuota=1024, filesLimit=1024, filesInDoubt=0, filesGrace='none'
+                ),
+            ],
+            '2510002': [
+                gpfs.StorageQuota(
+                    name='0', remarks='e', quota='on', defQuota='off', fid='0', filesetname='0',
+                    blockUsage=1025, blockQuota=1024, blockLimit=1024, blockInDoubt=0, blockGrace='expired',
+                    filesUsage=128, filesQuota=1024, filesLimit=1024, filesInDoubt=0, filesGrace='none'
+                ),
+            ],
+        },
+        'GRP': {
+            '2510001': [
+                gpfs.StorageQuota(
+                    name='0', remarks='', quota='on', defQuota='off', fid='0', filesetname='0',
+                    blockUsage=4, blockQuota=1024, blockLimit=1024, blockInDoubt=0, blockGrace='none',
+                    filesUsage=1, filesQuota=1024, filesLimit=1024, filesInDoubt=0, filesGrace='none'
+                ),
+            ],
+        },
+    },
+}
 
 class ToolsTest(TestCase):
     """
@@ -115,14 +162,8 @@ class ToolsTest(TestCase):
     @mock.patch('vsc.filesystem.gpfs.GpfsOperations.list_filesets')
     def test_create_filesystem_snapshot(self, mock_filesets, mock_list, mock_exec):
         mock_list.return_value = ['autumn_20151012', 'okt_20151028']
-        mock_filesets.return_value = {
-            'fstest': {
-                '0': {'filesetName': 'foo'},
-                '1': {'filesetName': 'bar'},
-                '2': {'filesetName': 'fs1'},
-                '3': {'filesetName': 'fs2'},
-            },
-        }
+        mock_filesets.return_value = TEST_LOCAL_FILESETS
+
         gpfsi = gpfs.GpfsOperations()
         self.assertEqual(gpfsi.create_filesystem_snapshot('fstest', 'okt_20151028'), 0)
         mock_exec.return_value = (1, 'mocked!')
@@ -282,3 +323,37 @@ mmhealth:State:0:1:::test01.gastly.data:OBJECT:test01.gastly.data:NODE:DISABLED:
         res = gpfsi.get_mmhealth_state()
         print(res)
         self.assertEqual(res, expected_res)
+
+    @mock.patch('vsc.filesystem.gpfs.GpfsOperations.list_filesets')
+    def test_get_fileset_name(self, mock_list):
+        mock_list.return_value = True
+
+        gpfsi = gpfs.GpfsOperations()
+        gpfsi.gpfslocalfilesets = TEST_LOCAL_FILESETS
+        self.assertEqual(gpfsi.get_fileset_name('0', 'fstest'), 'foo')
+        self.assertRaises(gpfs.GpfsOperationError, gpfsi.get_fileset_name, '-1', 'fstest')
+
+    def test_get_quota_fileset(self):
+        gpfsi = gpfs.GpfsOperations()
+        gpfsi.gpfslocalquotas = TEST_LOCAL_QUOTAS
+        self.assertEqual(gpfsi.get_quota_fileset('0', 'fstest'), '0')
+        self.assertRaises(gpfs.GpfsOperationError, gpfsi.get_quota_fileset, '-1', 'fstest')
+
+    def test_get_quota_fileset(self):
+        gpfsi = gpfs.GpfsOperations()
+        gpfsi.gpfslocalquotas = TEST_LOCAL_QUOTAS
+        self.assertEqual(gpfsi.get_quota_owner('2510001', 'fstest'), '2510001')
+        self.assertRaises(gpfs.GpfsOperationError, gpfsi.get_quota_owner, '-1', 'fstest')
+
+    def test_determine_grace_periods(self):
+        gpfsi = gpfs.GpfsOperations()
+
+        ref_grace = {
+            '2510001': ((False, None), (False, None)),
+            '2510002': ((True, 0), (False, None)),
+        }
+
+        for test_user in TEST_LOCAL_QUOTAS['fstest']['USR']:
+            for test_quota in TEST_LOCAL_QUOTAS['fstest']['USR'][test_user]:
+                test_grace = gpfsi.determine_grace_periods(test_quota)
+                self.assertEqual(test_grace, ref_grace[test_user])


### PR DESCRIPTION
In Brussels, we now have different storage backends for the different VSC filesystems. VSC_HOME and VSC_DATA are using an off-cluster storage from Huawei called OceanStor, and VSC_SCRATCH is using the usual GPFS filesystem. Therefore, we enhanced `VscStorage` to support different backends for each filesystem described in `STORAGE_CONFIGURATION_FILE`.

Depends on https://github.com/hpcugent/vsc-config/pull/177

As part of the same update, we are also integrating some changes into vsc-filesystems to help make vsc-administration and vsc-filesystems-quotas agnostic to the storage backend.

Changelog:
* add new `gpfs.operator` module with methods to dynamically initialize the `XxxxOperations` object based on the `backend` attribute of `VscStorage`, as suggested in https://github.com/hpcugent/vsc-config/pull/177
* integrate `determine_grace_periods` from vsc-filesystems-quota into `GpfsOperations` as the code in this method is specific to the storage backend
* add new methods to `GpfsOperations`: `get_fileset_name`, `get_quota_fileset` and `get_quota_owner`; these three methods gather code previously hardcoded in vsc-filesystems-quota that is specific to GPFS
* replace hardcoded quota type labels with Enum `Typ2Param`, similar to what is already done in Lustre
* rename `GpfsQuota` with a generic name `StorageQuota`
* add `who` keyword argument to methods `set_user_grace` and `set_group_grace` in `GpfsOperations` and `LustreOperations` (just added for compatibility with OceanStorOperations, nothing is done with it here)