### PR TITLE
replace MonoidDicts concatenating lists with defaultdict

### DIFF
--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -26,14 +26,14 @@ import copy
 import os
 import re
 
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 from vsc.utils.py2vs3 import unquote as percentdecode
 from socket import gethostname
 from itertools import dropwhile
 
 from vsc.config.base import GPFS_DEFAULT_INODE_LIMIT
 from vsc.filesystem.posix import PosixOperations, PosixOperationError
-from vsc.utils.missing import nub, find_sublist_index, MonoidConcat, MonoidDict, RUDict
+from vsc.utils.missing import nub, find_sublist_index, RUDict
 from vsc.utils.patterns import Singleton
 
 GPFS_BIN_PATH = '/usr/lpp/mmfs/bin'
@@ -221,13 +221,12 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
                     fields[i:i + 1] = map(lambda fs: (len(fs), fs), fixed_lines)
 
         # assemble result
-        listm = MonoidConcat()
-        res = MonoidDict(listm)
+        res = defaultdict(list)
         try:
             for index, name in enumerate(fields[0][1][6:]):
                 if name != '':
                     for (_, line) in fields[1:]:
-                        res[name] = [line[6 + index]]
+                        res[name].append(line[6 + index])
         except IndexError:
             self.log.raiseException("Failed to regroup data %s (from output %s)" % (fields, out))
 
@@ -369,12 +368,11 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
         elif isinstance(devices, str):
             devices = [devices]
 
-        listm = MonoidConcat()
-        info = MonoidDict(listm)
+        info = defaultdict(list)
         for device in devices:
             res = self._executeY('mmrepquota', ['-n', device], prefix=True)
             for (key, value) in res.items():
-                info[key] = value
+                info[key].extend(value)
 
         datakeys = list(info.keys())
         datakeys.remove('filesystemName')
@@ -385,16 +383,16 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
         self.log.debug("Found the following filesystem names: %s", fss)
 
         quotatypes = nub(info.get('quotaType', []))
-        quotatypesstruct = dict([(qt, MonoidDict(MonoidConcat())) for qt in quotatypes])
+        quotatypesstruct = {qt: defaultdict(list) for qt in quotatypes}
 
-        res = dict([(fs, copy.deepcopy(quotatypesstruct)) for fs in fss])  # build structure
+        res = {fs: copy.deepcopy(quotatypesstruct) for fs in fss}  # build structure
 
         for idx, (fs, qt, qid) in enumerate(zip(info['filesystemName'], info['quotaType'], info['id'])):
-            details = dict([(k, info[k][idx]) for k in datakeys])
+            details = {k: info[k][idx] for k in datakeys}
             if qt == 'FILESET':
                 # GPFS fileset quota have empty filesetName field
                 details['filesetname'] = details['name']
-            res[fs][qt][qid] = [GpfsQuota(**details)]
+            res[fs][qt][qid].append(GpfsQuota(**details))
 
         self.gpfslocalquotas = res
         return res
@@ -436,8 +434,7 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
 
         self.log.debug("Looking up filesets for devices %s", devices)
 
-        listm = MonoidConcat()
-        info = MonoidDict(listm)
+        info = defaultdict(list)
         for device in devices:
             opts_ = copy.deepcopy(opts)
             opts_.insert(1, device)
@@ -451,7 +448,7 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
             # afmParallelReadChunkSize:afmParallelReadThreshold:snapId:
             self.log.debug("list_filesets res keys = %s ", res.keys())
             for (key, value) in res.items():
-                info[key] = value
+                info[key].extend(value)
 
         datakeys = list(info.keys())
         datakeys.remove('filesystemName')

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -33,7 +33,7 @@ from itertools import dropwhile
 
 from vsc.config.base import GPFS_DEFAULT_INODE_LIMIT
 from vsc.filesystem.posix import PosixOperations, PosixOperationError
-from vsc.utils.missing import nub, find_sublist_index, Monoid, MonoidDict, RUDict
+from vsc.utils.missing import nub, find_sublist_index, MonoidConcat, MonoidDict, RUDict
 from vsc.utils.patterns import Singleton
 
 GPFS_BIN_PATH = '/usr/lpp/mmfs/bin'
@@ -221,7 +221,7 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
                     fields[i:i + 1] = map(lambda fs: (len(fs), fs), fixed_lines)
 
         # assemble result
-        listm = Monoid([], lambda xs, ys: xs + ys)  # not exactly the fastest mappend for lists ...
+        listm = MonoidConcat()
         res = MonoidDict(listm)
         try:
             for index, name in enumerate(fields[0][1][6:]):
@@ -369,7 +369,7 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
         elif isinstance(devices, str):
             devices = [devices]
 
-        listm = Monoid([], lambda xs, ys: xs + ys)  # not exactly the fastest mappend for lists ...
+        listm = MonoidConcat()
         info = MonoidDict(listm)
         for device in devices:
             res = self._executeY('mmrepquota', ['-n', device], prefix=True)
@@ -385,7 +385,7 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
         self.log.debug("Found the following filesystem names: %s", fss)
 
         quotatypes = nub(info.get('quotaType', []))
-        quotatypesstruct = dict([(qt, MonoidDict(Monoid([], lambda xs, ys: xs + ys))) for qt in quotatypes])
+        quotatypesstruct = dict([(qt, MonoidDict(MonoidConcat())) for qt in quotatypes])
 
         res = dict([(fs, copy.deepcopy(quotatypesstruct)) for fs in fss])  # build structure
 
@@ -436,7 +436,7 @@ class GpfsOperations(with_metaclass(Singleton, PosixOperations)):
 
         self.log.debug("Looking up filesets for devices %s", devices)
 
-        listm = Monoid([], lambda xs, ys: xs + ys)
+        listm = MonoidConcat()
         info = MonoidDict(listm)
         for device in devices:
             opts_ = copy.deepcopy(opts)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, kh, sdw, kw, wdp
 
 install_requires = [
-    'vsc-base >= 3.0.3',
+    'vsc-base >= 3.4.7',
     'vsc-config >= 3.0.0',
     'vsc-utils >= 2.0.0',
     'future >= 0.16.0',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, kh, sdw, kw, wdp
 
 install_requires = [
-    'vsc-base >= 3.4.7',
+    'vsc-base >= 3.5.0',
     'vsc-config >= 3.0.0',
     'vsc-utils >= 2.0.0',
     'future >= 0.16.0',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ else:
     install_requires.append('pyyaml')
 
 PACKAGE = {
-    'version': '1.2.19',
+    'version': '1.2.20',
     'author': [sdw, ag, kh, kw],
     'maintainer': [sdw, ag, kh, kw, wdp],
     'setup_requires': ['vsc-install >= 0.15.2'],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, kh, sdw, kw, wdp
 
 install_requires = [
-    'vsc-base >= 3.5.0',
+    'vsc-base >= 3.0.3',
     'vsc-config >= 3.0.0',
     'vsc-utils >= 2.0.0',
     'future >= 0.16.0',


### PR DESCRIPTION
This PR replaces the `Monoid` and `MonoidDict` objects in `GpfsOperations` with ~~`MonoidConcat`~~ `collections.defaultdict` in those cases where it is used to concatenate lists of attributes.

~~Depends on https://github.com/hpcugent/vsc-base/pull/330~~

The execution time of `GpfsOperations.list_quota()` with 24500 records from `mmrepquota` goes down from 194s to 9s.

## Update to defaultdict

Moving one step further by replacing all `MonoidDict` with `defaultdict`. This change is rather trivial actually and it results in an even larger performance gain for `GpfsOperations`.

1.  `Monoid` with current mappend used by vsc-filesystems:
    ```
    l = lambda xs, ys: xs + ys
    ```
2. `MonoidConcat` without `reduce` from https://github.com/hpcugent/vsc-base/pull/330
3. `defaultdict` from this PR
    
| Nr of records | 1: a + b (s) | 2: MonoidConcat (s) | 3: defaultdict |
| ------------- | ------------- | ------------- | ------------- |
| 100  | 0.0227  | 0.0155 | 0.0025 |
| 1000  | 0.3881  | 0.1381 | 0.0232 |
| 10000  | 30.4001  | 1.3504 | 0.1519 |
| 20000  | 122.6388  | 2.3829 | 0.2451 |
|   |   |   |   |
| `list_quota()` | 194.1 | 12.2 | 8.6 |
