### PR TITLE
avoid PosixOperations.ignorerealpathmismatch reset on chown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
 ]
 
 PACKAGE = {
-    'version': '2.2.1',
+    'version': '2.2.2',
     'author': [sdw, ag, kh, kw],
     'maintainer': [sdw, ag, kh, kw, wdp],
     'setup_requires': ['vsc-install >= 0.15.2'],

--- a/test/posix.py
+++ b/test/posix.py
@@ -36,7 +36,7 @@ class PosixTest(TestCase):
 
         self.po = PosixOperations()
         # mock the sanity check, to ease testing
-        self.po._sanity_check = lambda x: x
+        self.po._sanity_check = lambda x, y=False: x
 
     def test_is_dir(self):
         """Tests for is_dir method."""


### PR DESCRIPTION
The class attribute `PosixOperations.ignorerealpathmismatch` gets hard reset to _False_ every time that `chown` is called, overriding any setting on init.

This change was introduced in https://github.com/hpcugent/vsc-filesystems/commit/069375f607b2342fff6816c52cfb7a1aa584e8e5

This PR fixes this behaviour by adding a `force_ignorerealpath` argument to `_sanity_check` that introduces a soft switch to ignore real path mismatches without changing the class attribute.