### PR TITLE
fix: lock pyyaml to 6.0.1 for python 3.6

### DIFF
--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/__init__.py
+++ b/lib/vsc/filesystem/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/ext.py
+++ b/lib/vsc/filesystem/ext.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/lustre.py
+++ b/lib/vsc/filesystem/lustre.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2023 Ghent University
+# Copyright 2020-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/operator.py
+++ b/lib/vsc/filesystem/operator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2023 Ghent University
+# Copyright 2009-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,8 @@ vsc-filesystems base distribution setup.py
 @author: Stijn De Weirdt (Ghent University)
 @author: Andy Georges (Ghent University)
 """
+import sys
+
 import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, kh, sdw, kw, wdp
 
@@ -25,8 +27,11 @@ install_requires = [
     "vsc-base >= 3.0.3",
     "vsc-config >= 3.13.1",
     "vsc-utils >= 2.0.0",
-    "pyyaml <= 6.0.1",
 ]
+
+if sys.version_info < (3,9):
+    install_requires.append("pyyaml <= 6.0.1")
+
 
 PACKAGE = {
     "version": "2.2.4",

--- a/setup.py
+++ b/setup.py
@@ -22,20 +22,20 @@ import vsc.install.shared_setup as shared_setup
 from vsc.install.shared_setup import ag, kh, sdw, kw, wdp
 
 install_requires = [
-    'vsc-base >= 3.0.3',
-    'vsc-config >= 3.13.1',
-    'vsc-utils >= 2.0.0',
-    'pyyaml',
+    "vsc-base >= 3.0.3",
+    "vsc-config >= 3.13.1",
+    "vsc-utils >= 2.0.0",
+    "pyyaml <= 6.0.1",
 ]
 
 PACKAGE = {
-    'version': '2.2.4',
-    'author': [sdw, ag, kh, kw],
-    'maintainer': [sdw, ag, kh, kw, wdp],
-    'setup_requires': ['vsc-install >= 0.15.2'],
-    'tests_require': ['mock'],
-    'install_requires': install_requires
+    "version": "2.2.4",
+    "author": [sdw, ag, kh, kw],
+    "maintainer": [sdw, ag, kh, kw, wdp],
+    "setup_requires": ["vsc-install >= 0.15.2"],
+    "tests_require": ["mock"],
+    "install_requires": install_requires,
 }
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     shared_setup.action_target(PACKAGE)

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,13 @@ install_requires = [
 
 if sys.version_info < (3,9):
     install_requires.append("pyyaml <= 6.0.1")
+else:
+    install_requires.append("pyyaml")
+
 
 
 PACKAGE = {
-    "version": "2.2.4",
+    "version": "2.3.0",
     "author": [sdw, ag, kh, kw],
     "maintainer": [sdw, ag, kh, kw, wdp],
     "setup_requires": ["vsc-install >= 0.15.2"],

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2023 Ghent University
+# Copyright 2016-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/gpfs.py
+++ b/test/gpfs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 Ghent University
+# Copyright 2015-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/lustre.py
+++ b/test/lustre.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2023 Ghent University
+# Copyright 2015-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/posix.py
+++ b/test/posix.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2023 Ghent University
+# Copyright 2014-2024 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,17 @@
 envlist = py36,py39
 skipsdist = true
 
-[testenv]
+[testenv:py36]
 commands_pre =
     pip install 'setuptools<42.0'
     python -m easy_install -U vsc-install
+
+[testenv:py39]
+setenv = SETUPTOOLS_USE_DISTUTILS=local
+commands_pre =
+    pip install 'setuptools<54.0' wheel
+    python -c "from setuptools import setup;setup(script_args=['-q', 'easy_install', '-v', '-U', 'vsc-install'])"
+
+[testenv]
 commands = python setup.py test
 passenv = USER


### PR DESCRIPTION
6.0.2rc1 has a bug in py36