### PR TITLE
add replace_acl method to PosixOperations

### DIFF
--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -821,6 +821,11 @@ class GpfsOperations(PosixOperations, metaclass=Singleton):
         # by swithcing to chmodAndUpdateAcl, chmod behaves in the same way (updates) both ACL types
         mmcrfileset_options += ['--allow-permission-change', 'chmodAndUpdateAcl']
 
+        # Remove special permissions (i.e. owner, group, everyone) from inheritance rules in ACLs
+        # this allows to control special permissions as usual with mod bits and umask
+        # only named ACLs will be inherited
+        mmcrfileset_options += ['--allow-permission-inherit', 'inheritAclAndAddMode']
+
         (ec, out) = self._execute('mmcrfileset', mmcrfileset_options, True)
         if ec > 0:
             self.log.raiseException(

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -816,6 +816,11 @@ class GpfsOperations(PosixOperations, metaclass=Singleton):
                     GpfsOperationError)
             mmcrfileset_options += ['--inode-space', parent_fileset_name]
 
+        # Enable update of ACL permissions on chmod commands in all cases
+        # default setting is chmodAndSetAcl, which makes chmod update POSIX ACLs, but fully replace NFS4 ACLs
+        # by swithcing to chmodAndUpdateAcl, chmod behaves in the same way (updates) both ACL types
+        mmcrfileset_options += ['--allow-permission-change', 'chmodAndUpdateAcl']
+
         (ec, out) = self._execute('mmcrfileset', mmcrfileset_options, True)
         if ec > 0:
             self.log.raiseException(

--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -22,6 +22,7 @@ General POSIX filesystem interaction (sort of replacement for linux_utils)
 import errno
 import os
 import stat
+import tempfile
 
 from vsc.utils import fancylogger
 from vsc.utils.patterns import Singleton
@@ -558,3 +559,66 @@ class PosixOperations(metaclass=Singleton):
             self.log.debug("Path %s already exists with correct ownership", path)
 
         return created
+
+    def replace_acl(self, path, permissions):
+        """
+        Overwrite ACL permissions on given path
+        """
+        path = self._sanity_check(path)
+        fs = self._what_filesystem(path)
+        if fs is None:
+            self.log.warning(f"ACL replacement requested on  filesystem with unknown support: {path}")
+            return False
+
+        if not isinstance(permissions, (tuple, list,)):
+            raise PosixOperationError("Given ACL permissions are not a list or tuple")
+
+        replace_acl_method = self._replace_acl_posix
+        if fs[0] in ['gpfs', 'nfs4']:
+            replace_acl_method = self._replace_acl_nfs
+
+        return replace_acl_method(path, permissions)
+
+    def _replace_acl_posix(self, path, permissions):
+        """
+        Overwrite ACL permissions in POSIX format on given path
+        """
+        setfacl_exe = 'setfacl'
+
+        with tempfile.NamedTemporaryFile() as acl_file:
+            self.log.debug(f"Input file for {setfacl_exe} created in: {acl_file.name}")
+            acl_file.write('\n'.join(permissions).encode('utf-8'))
+
+            setfacl_cmd = [
+                setfacl_exe,
+                f'--set-file={acl_file.name}',
+                path
+            ]
+
+            try:
+                ec, out = self._execute(setfacl_cmd)
+            except FileNotFoundError as err:
+                raise PosixOperationError(f"Cannot set POSIX ACLs, command {setfacl_exe} not found") from err
+            else:
+                return ec, out
+
+    def _replace_acl_nfs(self, path, permissions):
+        """
+        Overwrite ACL permissions in NFSv4 format on given path
+        """
+        acl_entries = ','.join(permissions)
+
+        setfacl_exe = 'nfs4_setfacl'
+        setfacl_cmd = [
+            'nfs4_setfacl',
+            '-s',
+            f'"{acl_entries}"',
+            path
+        ]
+
+        try:
+            ec, _ = self._execute(setfacl_cmd)
+        except FileNotFoundError as err:
+            raise PosixOperationError(f"Cannot set NFSv4 ACLs, command {setfacl_exe} not found") from err
+        else:
+            return ec

--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -587,7 +587,9 @@ class PosixOperations(metaclass=Singleton):
 
         with tempfile.NamedTemporaryFile() as acl_file:
             self.log.debug(f"Input file for {setfacl_exe} created in: {acl_file.name}")
-            acl_file.write('\n'.join(permissions).encode('utf-8'))
+            acl_entries = '\n'.join(permissions)
+            acl_file.write(acl_entries.encode('utf-8'))
+            self.log.debug(f"Setting POSIX ACLs on '{path}' to:\n{acl_entries}")
 
             setfacl_cmd = [
                 setfacl_exe,
@@ -607,6 +609,7 @@ class PosixOperations(metaclass=Singleton):
         Overwrite ACL permissions in NFSv4 format on given path
         """
         acl_entries = ','.join(permissions)
+        self.log.debug(f"Setting NFSv4 ACLs on '{path}' to: {acl_entries}")
 
         setfacl_exe = 'nfs4_setfacl'
         setfacl_cmd = [

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ else:
 
 
 PACKAGE = {
-    "version": "2.3.2",
+    "version": "2.4.0",
     "author": [sdw, ag, kh, kw],
     "maintainer": [sdw, ag, kh, kw, wdp],
     "setup_requires": ["vsc-install >= 0.15.2"],

--- a/test/posix.py
+++ b/test/posix.py
@@ -240,3 +240,42 @@ class PosixTest(TestCase):
 
         mock_os_stat.assert_called_with(test_path)
         mock_makedirs.assert_not_called
+
+    @mock.patch('vsc.filesystem.posix.PosixOperations._execute')
+    @mock.patch('vsc.filesystem.posix.PosixOperations._what_filesystem')
+    @mock.patch('vsc.filesystem.posix.tempfile.NamedTemporaryFile')
+    def test_replace_acl(self, mock_tempfile, mock_what_filesystem, mock_execute):
+        """
+        Test replacement of ACLs
+        """
+        mock_aclfile = mock.MagicMock()
+        mock_aclfile.name = "/tmp/acl_input_file"
+        mock_context = mock.MagicMock()
+        mock_context.__enter__.return_value = mock_aclfile
+        mock_tempfile.return_value = mock_context
+        mock_execute.return_value = (0, "")
+        test_path = '/tmp/test'
+
+        # POSIX ACLs
+        mock_what_filesystem.return_value = ['posix', '/data', 0, '127.0.0.1@tcp']
+
+        test_acl_posix = "user::rwx"
+        self.assertRaises(PosixOperationError, self.po.replace_acl, test_path, test_acl_posix)
+
+        test_acl_posix = ["user::rwx", "group::r-x", "other::r-x"]
+        self.po.replace_acl(test_path, test_acl_posix)
+        mock_execute.assert_called_with(
+            ['setfacl', '--set-file=/tmp/acl_input_file', '/tmp/test']
+        )
+
+        # NFSv4 ACLs
+        mock_what_filesystem.return_value = ['nfs4', '/data', 0, '127.0.0.1@tcp']
+
+        test_acl_posix = "A:d:OWNER@:rwaDdxtTnNcoy"
+        self.assertRaises(PosixOperationError, self.po.replace_acl, test_path, test_acl_posix)
+
+        test_acl_posix = ["A:d:OWNER@:rwaDdxtTnNcoy", "A:dg:GROUP@:rxtncy", "A:fd:EVERYONE@:tncy"]
+        self.po.replace_acl(test_path, test_acl_posix)
+        mock_execute.assert_called_with(
+            ['nfs4_setfacl', '-s', '"A:d:OWNER@:rwaDdxtTnNcoy,A:dg:GROUP@:rxtncy,A:fd:EVERYONE@:tncy"', '/tmp/test']
+        )


### PR DESCRIPTION
In VUB we are going to start controlling access to our VOs with ACLs. To this end we need a method in `vsc-filesystems` that allows to set those ACLs.

`PosixOperations.replace_acl` will replace the ACLs of an object with the given ACL entries. It uses NFSv4 formatting on `nfs4` and `gpfs` mounts and POSIX formatting anywhere else.

This is needed by https://github.com/hpcugent/vsc-administration/pull/159

Moreover, on GPFS we need the following changes to default settings to make ACL behaviour on filesets be usable:
* `--allow-permission-change=chmodAndUpdateAcl`: otherwise `chmod` commands reset the NFSv4 ACLs. This change only impacts files/folders with NFS4 ACLs, behaviour without ACLs or with POSIX ACLs is unaffected.
* `--allow-permission-inherit=inheritAclAndAddMode`: keep special permissions (owner, group, everyone) out of the ACL inheritance to continue manage those with the usual mod bits and umask.