### PR TITLE
only reset directory group owner with override_permissions enabled

### DIFF
--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -551,9 +551,17 @@ class PosixOperations(metaclass=Singleton):
         else:
             self.log.debug("Path %s already exists with correct permissions", path)
 
-        if created or statinfo.st_uid != uid or statinfo.st_gid != gid:
-            self.chown(uid, gid, path)
-            self.log.info("Ownership changed for path %s to %d, %d", path, uid, gid)
+        if created:
+            self.chown(uid, group=gid, obj=path)
+            self.log.info("Ownership changed for new directory %s to %d, %d", path, uid, gid)
+        elif override_permissions and statinfo.st_gid != gid:
+            # only reset group owner if requested
+            self.chown(uid, group=gid, obj=path)
+            self.log.info("Group ownership reset for directory %s to %d, %d", path, uid, gid)
+        elif statinfo.st_uid != uid:
+            # always reset user owner
+            self.chown(uid, obj=path)
+            self.log.info("User ownership reset for directory %s to %d", path, uid)
         else:
             self.log.debug("Path %s already exists with correct ownership", path)
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ else:
 
 
 PACKAGE = {
-    "version": "2.3.2",
+    "version": "2.4.0",
     "author": [sdw, ag, kh, kw],
     "maintainer": [sdw, ag, kh, kw, wdp],
     "setup_requires": ["vsc-install >= 0.15.2"],

--- a/test/posix.py
+++ b/test/posix.py
@@ -164,7 +164,7 @@ class PosixTest(TestCase):
 
         mock_os_stat.assert_called_with(test_path)
         mock_makedirs.assert_not_called
-        mock_chown.assert_called_with(test_path, test_uid, test_gid)
+        mock_chown.assert_called_with(test_path, test_uid, None)
 
     @mock.patch('vsc.filesystem.posix.os.stat')
     @mock.patch('stat.S_ISDIR')
@@ -188,7 +188,7 @@ class PosixTest(TestCase):
 
         mock_os_stat.assert_called_with(test_path)
         mock_makedirs.assert_not_called
-        mock_chown.assert_called_with(test_path, test_uid, test_gid)
+        mock_chown.assert_called_with(test_path, test_uid, None)
 
     @mock.patch('vsc.filesystem.posix.os.stat')
     @mock.patch('stat.S_ISDIR')


### PR DESCRIPTION
We currently have the `override_permissions` flag in `PosixOperations.create_stat_directory` which controls when we set/reset the permissions bits on the target path.

We want to extend this to the group owner of the folder.

Motivation is that if users want to change the primary group of their user folders in a VO, that should stay untouched by our scripts. The `override_permissions` flag is already disabled for user folders in VOs, but that only applies to permissions currently.