### PR TITLE
Allow multiple filesystems

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,15 +2,25 @@
 // This file was automatically generated using 'python -m vsc.install.ci'
 // DO NOT EDIT MANUALLY
 
-node {
+pipeline {
+agent any
+stages {
     stage('checkout git') {
-        checkout scm
-        // remove untracked files (*.pyc for example)
-        sh 'git clean -fxd'
+        steps {
+            checkout scm
+            // remove untracked files (*.pyc for example)
+            sh 'git clean -fxd'
+        }
     }
-    stage('test') {
-        sh 'pip3 install --ignore-installed --prefix $PWD/.vsc-tox tox'
-        sh 'export PATH=$PWD/.vsc-tox/bin:$PATH && export PYTHONPATH=$PWD/.vsc-tox/lib/python$(python3 -c "import sys; print(\\"%s.%s\\" % sys.version_info[:2])")/site-packages:$PYTHONPATH && tox -v -c tox.ini'
-        sh 'rm -r $PWD/.vsc-tox'
+    stage('test pipeline') {
+        parallel {
+            stage('test') {
+                steps {
+                    sh 'pip3 install --ignore-installed --prefix $PWD/.vsc-tox tox'
+                    sh 'export PATH=$PWD/.vsc-tox/bin:$PATH && export PYTHONPATH=$PWD/.vsc-tox/lib/python$(python3 -c "import sys; print(\\"%s.%s\\" % sys.version_info[:2])")/site-packages:$PYTHONPATH && tox -v -c tox.ini'
+                    sh 'rm -r $PWD/.vsc-tox'
+                }
+            }
+        }
     }
-}
+}}

--- a/lib/vsc/__init__.py
+++ b/lib/vsc/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: latin-1 -*-
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/__init__.py
+++ b/lib/vsc/filesystem/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/ext.py
+++ b/lib/vsc/filesystem/ext.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/gpfs.py
+++ b/lib/vsc/filesystem/gpfs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/lustre.py
+++ b/lib/vsc/filesystem/lustre.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2020-2025 Ghent University
+# Copyright 2020-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/operator.py
+++ b/lib/vsc/filesystem/operator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -43,6 +43,7 @@ OS_LINUX_IGNORE_FILESYSTEMS = (
     'fuse.sshfs',  # X2GO sshfs over fuse
     'fuse.irods',  # irods fuse
     'fuse.irodsfs',  # irods nfs fuse
+    'tmpfs',  # with mountnames this can cause issues
 )
 
 

--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -217,14 +217,10 @@ class PosixOperations(metaclass=Singleton):
                 f"No matching filesystem found for obj {obj} id {fsid} (localfilesystems: {self.localfilesystems})",
                 PosixOperationError)
         elif len(fss) > 1:
-            self.log.raiseException(
-                f"More than one matching filesystem found for obj {obj} with id {fsid} "
-                f"(matched localfilesystems: {fsid})",
-                PosixOperationError)
-        else:
-            self.log.debug("Found filesystem for obj %s: %s", obj, fss[0])
-            return fss[0]
-        return None
+            self.log.debug("Found multiple filesystem (first one will be used) for obj %s: %s", obj, fss)
+
+        self.log.debug("Found filesystem for obj %s: %s", obj, fss[0])
+        return fss[0]
 
     def _local_filesystems(self):
         """What filesystems are mounted / available atm"""

--- a/lib/vsc/filesystem/posix.py
+++ b/lib/vsc/filesystem/posix.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2009-2025 Ghent University
+# Copyright 2009-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ else:
 
 
 PACKAGE = {
-    "version": "2.3.2",
+    "version": "2.3.3",
     "author": [sdw, ag, kh, kw],
     "maintainer": [sdw, ag, kh, kw, wdp],
     "setup_requires": ["vsc-install >= 0.15.2"],

--- a/test/00-import.py
+++ b/test/00-import.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2024 Ghent University
+# Copyright 2016-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2024 Ghent University
+# Copyright 2016-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/gpfs.py
+++ b/test/gpfs.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2024 Ghent University
+# Copyright 2015-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/lustre.py
+++ b/test/lustre.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2024 Ghent University
+# Copyright 2015-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/posix.py
+++ b/test/posix.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2014-2024 Ghent University
+# Copyright 2014-2026 Ghent University
 #
 # This file is part of vsc-filesystems,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
When bind mounts are in use, this automatically happens. There is no reason for concern about it.